### PR TITLE
chore: migrate Prettier config to separate file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,18 +50,6 @@
   "lint-staged": {
     "*.{js,ts,tsx,md,yml,json}": "prettier --write"
   },
-  "prettier": {
-    "arrowParens": "always",
-    "plugins": [
-      "prettier-plugin-packagejson"
-    ],
-    "printWidth": 120,
-    "semi": true,
-    "singleQuote": true,
-    "tabWidth": 2,
-    "trailingComma": "all",
-    "useTabs": false
-  },
   "release": {
     "branches": [
       "main"

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,10 @@
+export default {
+  arrowParens: "always",
+  plugins: ["prettier-plugin-packagejson"],
+  printWidth: 120,
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: "all",
+  useTabs: false,
+};


### PR DESCRIPTION
## Summary

This PR migrates Prettier configuration from `package.json` to a dedicated `prettier.config.js` file.

## Changes

- Created `prettier.config.js` with all existing Prettier settings
- Removed `prettier` field from `package.json`
- Functionality remains unchanged, just better organized

## Benefits

- Follows common project structure patterns
- Improves maintainability
- Separates configuration concerns