### PR TITLE
build: fix release commit message type and update CLAUDE.md

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,6 @@
 {
   "git": {
-    "commitMessage": "chore: release v${version}",
+    "commitMessage": "build: release v${version}",
     "requireBranch": "main"
   },
   "npm": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ This project uses **Conventional Commits** (Angular preset) enforced by commitli
 ### Rules
 
 - Follow the format: `type(scope?): subject`
-- **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, etc.
+- **Types**: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
 - **Subject**: Brief description in imperative mood
 - **Body**: Optional detailed explanation
   - **Important**: Each line must not exceed 100 characters


### PR DESCRIPTION
## Summary

Fix the release-it commit message type to resolve CI failure.

## Problem

PR #88 was merged, but the release workflow fails with:
- release-it creates commit with 
- commitlint rejects  (not in allowed types list)

## Changes

### .release-it.json
- Change  from  to 

### CLAUDE.md
- Fix Line 143: Update allowed types list to match @commitlint/config-angular
- Remove  
- Add accurate list: , , , , , , , , , 

## Related

- Fixes the issue found in: https://github.com/wadackel/gha-docgen/actions/runs/18252115946/job/51968033895