### PR TITLE
fix: use release-it after:bump hook for building artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,9 +69,6 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
 
-      - name: Build package
-        run: pnpm build
-
       - name: Configure git
         run: |
           git config user.name "${GITHUB_ACTOR}"

--- a/.release-it.json
+++ b/.release-it.json
@@ -3,6 +3,9 @@
     "commitMessage": "build: release v${version}",
     "requireBranch": "main"
   },
+  "hooks": {
+    "after:bump": "pnpm build"
+  },
   "npm": {
     "skipChecks": true
   },


### PR DESCRIPTION
## Summary

Fix the build artifact generation timing to ensure dist/bin.js contains the correct version information.

## Problem

Current flow has a timing issue:
1. `pnpm build` runs (uses package.json v1.0.1)
2. `release-it` updates package.json to v1.0.2
3. `npm publish` publishes with **old** dist/bin.js containing v1.0.1

Additionally, v1.0.2 was already published in the previous failed CI run, causing:
```
npm error You cannot publish over the previously published versions: 1.0.2.
```

## Changes

### .release-it.json
- Add `hooks.after:bump: "pnpm build"`
- Rebuilds package **after** version bump, ensuring latest version info

### .github/workflows/ci.yaml
- Remove `Build package` step
- Build now happens via release-it hook at the correct timing

## Fixed Flow

```
1. release-it --ci
   ├─ npm version (updates package.json to v1.0.2)
   ├─ after:bump hook: pnpm build (rebuilds with v1.0.2)
   └─ npm publish (publishes with correct version)
```

## Related

- Fixes: https://github.com/wadackel/gha-docgen/actions/runs/18252212392/job/51968271861