### PR TITLE
fix: use release-it after:bump hook for building artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-docgen",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate documentation based on the Metadata of the GitHub Action.",
   "keywords": [
     "github",


### PR DESCRIPTION
## Summary

Fix the build artifact generation timing to ensure dist/bin.js contains the correct version information, and resolve the npm version conflict issue.

## Changes

### 1. Build Timing Fix

**Problem:**
Build was executed before version bump, causing dist/bin.js to contain outdated package.json version information.

**Solution:**
- Add `hooks.after:bump: "pnpm build"` to `.release-it.json`
- Remove `Build package` step from GitHub Actions workflow
- Now builds after version bump with correct version info

### 2. Version Conflict Resolution

**Problem:**
- v1.0.2 was published in a previous failed CI run
- npm does not allow republishing a version even after unpublishing
- Error: `Cannot publish over previously published version "1.0.2"`

**Solution:**
- Manually bump `package.json` version to 1.0.2
- Next release will be calculated as v1.0.3 by release-it
- v1.0.3 is a new version and can be published

## Modified Files

- `.release-it.json`: Added `after:bump` hook for building artifacts
- `.github/workflows/ci.yaml`: Removed pre-build step
- `package.json`: Version bumped to 1.0.2 to skip unpublishable version

## Release Flow After Merge

```
1. release-it --ci
   ├─ Current version: 1.0.2
   ├─ Analyze conventional commits (fix type found)
   ├─ Calculate next: 1.0.2 → 1.0.3 (PATCH bump)
   ├─ npm version 1.0.3
   ├─ after:bump hook: pnpm build (with v1.0.3)
   └─ npm publish 1.0.3 ✅
```