### PR TITLE
fix: enable git push authentication and proper build timing for release-it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,6 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-docgen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Generate documentation based on the Metadata of the GitHub Action.",
   "keywords": [
     "github",


### PR DESCRIPTION
## Summary

This PR fixes critical issues in the release-it migration that prevented successful releases:

- Add `after:bump` hook to ensure build artifacts contain correct version
- Fix git push authentication by using default `persist-credentials` behavior
- Bump version to 1.0.3 (next release will be 1.0.4)

## Background

During the migration from semantic-release to release-it (#88), several issues were discovered during CI execution:

1. **Build timing issue**: Build artifacts were created before version bump, resulting in dist/bin.js containing the old version
2. **Git push authentication failure**: The `persist-credentials: false` setting prevented git from authenticating during push

## Changes

### `.release-it.json`
- Added `hooks.after:bump: "pnpm build"` to rebuild after version bump
- Ensures dist/bin.js contains the correct version information

### `.github/workflows/ci.yaml`
- Removed `persist-credentials: false` from checkout step (defaults to true)
- Removed separate "Build package" step (now handled by after:bump hook)

### `package.json`
- Bumped version from 1.0.2 to 1.0.3
- Note: v1.0.3 was already published to npm during troubleshooting, so the next release will be v1.0.4

### `.gitignore`
- Added `.husky/` (generated by lefthook)
- Added `.npmrc` (created by release-it in CI)

## Related

- #88 - Initial migration to release-it