### PR TITLE
chore: update type-fest to v5.0.1 and move to dependencies

### DIFF
--- a/.changeset/type-fest-update.md
+++ b/.changeset/type-fest-update.md
@@ -1,0 +1,5 @@
+---
+'gha-docgen': patch
+---
+
+Update type-fest from v3.13.1 to v5.0.1 and move from devDependencies to dependencies

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "meow": "^14.0.0",
+    "type-fest": "^5.0.1",
     "yaml": "^2.2.1",
     "zod": "^3.21.4",
     "zod-error": "^1.5.0"
@@ -63,7 +64,6 @@
     "prettier": "3.6.2",
     "prettier-plugin-packagejson": "2.5.19",
     "tsdown": "0.15.5",
-    "type-fest": "3.13.1",
     "typescript": "5.9.2",
     "vitest": "0.34.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       meow:
         specifier: ^14.0.0
         version: 14.0.0
+      type-fest:
+        specifier: ^5.0.1
+        version: 5.0.1
       yaml:
         specifier: ^2.2.1
         version: 2.8.1
@@ -57,9 +60,6 @@ importers:
       tsdown:
         specifier: 0.15.5
         version: 0.15.5(typescript@5.9.2)
-      type-fest:
-        specifier: 3.13.1
-        version: 3.13.1
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -1135,6 +1135,10 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -1194,9 +1198,9 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
-  type-fest@3.13.1:
-    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
-    engines: {node: '>=14.16'}
+  type-fest@5.0.1:
+    resolution: {integrity: sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -2299,6 +2303,8 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tagged-tag@1.0.0: {}
+
   term-size@2.2.1: {}
 
   tinybench@2.9.0: {}
@@ -2350,7 +2356,9 @@ snapshots:
 
   type-detect@4.1.0: {}
 
-  type-fest@3.13.1: {}
+  type-fest@5.0.1:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.2: {}
 


### PR DESCRIPTION
## Summary

Updates `type-fest` from v3.13.1 to v5.0.1 and moves it from `devDependencies` to `dependencies` with `^` version prefix.

## Changes

- Update `type-fest` from v3.13.1 to v5.0.1
- Move `type-fest` from `devDependencies` to `dependencies`
- Use `^` version prefix for flexible minor/patch updates
- Add changeset for this update

## Verification

All checks have passed:
- ✅ Type checking
- ✅ All tests (30/30 passed)
- ✅ Build successful