### PR TITLE
chore: consolidate CI jobs into build_and_test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,49 +12,21 @@ on:
       - 'releases/*'
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-node
       - run: pnpm build
-
-  typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: ./.github/actions/setup-node
       - run: pnpm typecheck
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: ./.github/actions/setup-node
       - run: pnpm test
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: ./.github/actions/setup-node
       - run: pnpm lint
-
-  pass:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-      - typecheck
-      - test
-      - lint
-    steps:
-      - run: exit 0
 
   publish:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     needs:
-      - pass
+      - build_and_test
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Consolidate multiple CI jobs into a single `build_and_test` job to improve execution efficiency and simplify workflow management.

## Changes

- Merge `build`, `typecheck`, `test`, and `lint` jobs into single `build_and_test` job
- Remove unnecessary `pass` job
- Update `publish` job dependency to `build_and_test`

## Benefits

- Reduced CI execution time (setup runs only once)
- Simplified workflow structure and dependency graph
- Easier maintenance