### PR TITLE
chore: upgrade zod to v4.1.11

### DIFF
--- a/.changeset/upgrade-zod-v4.md
+++ b/.changeset/upgrade-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'gha-docgen': patch
+---
+
+Upgrade zod from v3.21.4 to v4.1.11 and replace zod-error with zod-validation-error for better error formatting

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "meow": "^14.0.0",
     "type-fest": "^5.0.1",
     "yaml": "^2.2.1",
-    "zod": "^3.21.4",
-    "zod-error": "^1.5.0"
+    "zod": "^4.1.11",
+    "zod-validation-error": "^4.0.2"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
         specifier: ^2.2.1
         version: 2.8.1
       zod:
-        specifier: ^3.21.4
-        version: 3.25.76
-      zod-error:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^4.1.11
+        version: 4.1.11
+      zod-validation-error:
+        specifier: ^4.0.2
+        version: 4.0.2(zod@4.1.11)
     devDependencies:
       '@changesets/cli':
         specifier: 2.29.7
@@ -1430,11 +1430,14 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod-error@1.5.0:
-    resolution: {integrity: sha512-zzopKZ/skI9iXpqCEPj+iLCKl9b88E43ehcU+sbRoHuwGd9F1IDVGQ70TyO6kmfiRL1g4IXkjsXK+g1gLYl4WQ==}
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
 
@@ -2665,8 +2668,8 @@ snapshots:
 
   yaml@2.8.1: {}
 
-  zod-error@1.5.0:
+  zod-validation-error@4.0.2(zod@4.1.11):
     dependencies:
-      zod: 3.25.76
+      zod: 4.1.11
 
-  zod@3.25.76: {}
+  zod@4.1.11: {}

--- a/src/__snapshots__/utils.test.ts.snap
+++ b/src/__snapshots__/utils.test.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generateZodErrorMessage 1`] = `"foo ~ Expected string, received number | bar.baz ~ Expected number, received string"`;
+exports[`generateZodErrorMessage 1`] = `"Invalid input: expected string, received number at "foo" | Invalid input: expected number, received string at "bar.baz""`;

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -62,7 +62,7 @@ try {
 
   const style = docgenStyleSchema.safeParse(cli.flags.style);
   if (!style.success) {
-    throw new Error(`Error invalid "--style" flag value: ${generateZodErrorMessage(style.error.issues)}`);
+    throw new Error(`Error invalid "--style" flag value: ${generateZodErrorMessage(style.error)}`);
   }
 
   await main({

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -123,7 +123,7 @@ test('invalid action.yml schema', async () => {
       style: 'section:h3',
     }),
   ).rejects.toThrowError(
-    'Error parsing action file: description ~ Required | inputs.github_token ~ Expected object, received string',
+    'Error parsing action file: Invalid input: expected string, received undefined at "description" | Invalid input: expected object, received string at "inputs.github_token"',
   );
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ export const main = async ({ debug, cwd, ...opts }: MainOptions): Promise<void> 
   const action = actionSchema.safeParse(actionObj);
   if (!action.success) {
     debug('action schema error: %s', action.error);
-    throw new Error(`Error parsing action file: ${generateZodErrorMessage(action.error.issues)}`);
+    throw new Error(`Error parsing action file: ${generateZodErrorMessage(action.error)}`);
   }
 
   // Read markdown files

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -24,7 +24,7 @@ test('generateZodErrorMessage', () => {
     throw new Error();
   }
 
-  expect(generateZodErrorMessage(res.error.issues)).toMatchSnapshot();
+  expect(generateZodErrorMessage(res.error)).toMatchSnapshot();
 });
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises';
-import type { ZodIssue } from 'zod';
-import { generateErrorMessage } from 'zod-error';
+import type { ZodError } from 'zod';
+import { fromZodError } from 'zod-validation-error';
 
 /**
  * Filesystem
@@ -26,21 +26,12 @@ export const write = async (filepath: string, data: string): Promise<Error | nul
 /**
  * Error handling
  */
-export const generateZodErrorMessage = (issues: ZodIssue[]): string => {
-  return generateErrorMessage(issues, {
-    code: {
-      enabled: false,
-    },
-    message: {
-      enabled: true,
-      label: '',
-    },
-    path: {
-      enabled: true,
-      type: 'objectNotation',
-      label: '',
-    },
-  });
+export const generateZodErrorMessage = (error: ZodError): string => {
+  return fromZodError(error, {
+    prefix: undefined,
+    issueSeparator: ' | ',
+    unionSeparator: ' OR ',
+  }).toString();
 };
 
 /**


### PR DESCRIPTION
## Summary

Upgrade zod from v3.21.4 to v4.1.11 with improved error formatting.

## Changes

- Upgrade `zod` from v3.21.4 to v4.1.11
- Replace `zod-error` with `zod-validation-error` for Zod v4 compatibility
- Update error message formatting logic to use `zod-validation-error`
- Update test assertions to match new error message format

## Error Message Format Improvement

**Before:**
```
foo ~ Expected string, received number | bar.baz ~ Expected number, received string
```

**After:**
```
Invalid input: expected string, received number at "foo" | Invalid input: expected number, received string at "bar.baz"
```

The new format provides clearer, more readable error messages while maintaining single-line output suitable for CLI tools.

## Migration Rationale

- `zod-error` (v1.5.0) has not been updated since Feb 2023 and does not support Zod v4
- `zod-validation-error` (v4.0.2) actively supports both Zod v3 and v4
- Zod v4's built-in `z.prettifyError()` was considered but produces multi-line output unsuitable for this CLI tool's error handling